### PR TITLE
Fix #27

### DIFF
--- a/tuw_multi_robot_ctrl/CMakeLists.txt
+++ b/tuw_multi_robot_ctrl/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(catkin REQUIRED COMPONENTS
   tuw_multi_robot_msgs
   tuw_nav_msgs
   nodelet
+  tuw_local_controller_msgs
 )
 
 ## System dependencies are found with CMake's conventions

--- a/tuw_multi_robot_ctrl/package.xml
+++ b/tuw_multi_robot_ctrl/package.xml
@@ -48,6 +48,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>tuw_multi_robot_msgs</build_depend>
+  <build_depend>tuw_local_controller_msgs</build_depend>
   <build_depend>tuw_nav_msgs</build_depend>
   <build_depend>nodelet</build_depend>
   <exec_depend>geometry_msgs</exec_depend>
@@ -56,6 +57,7 @@
   <exec_depend>roscpp</exec_depend>
   <exec_depend>tf</exec_depend>
   <exec_depend>tuw_multi_robot_msgs</exec_depend>
+  <exec_depend>tuw_local_controller_msgs</exec_depend>
   <exec_depend>tuw_nav_msgs</exec_depend>
   <exec_depend>nodelet</exec_depend>
 


### PR DESCRIPTION
Adding this dependency will allow tuw_multi_robot_ctrl to build also in isolated mode using `catkin build`.